### PR TITLE
Two-level error system : Rename

### DIFF
--- a/src/PureMachine/Bundle/SDKBundle/Exception/ExceptionElementInterface.php
+++ b/src/PureMachine/Bundle/SDKBundle/Exception/ExceptionElementInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace PureMachine\Bundle\SDKBundle\Exception;
+
+/**
+ * Interface ExceptionElementInterface
+ *
+ * Implementing this interface, tags the object with the
+ * next inherited method (should be implemented with direct
+ * method definition or with __call hook)
+ *
+ *   getErrorMessage()
+ *   getErrorCode()
+ *   getDetailedErrorMessage()
+ *   getDetailedErrorCode()
+ *   setErrorMessage()
+ *   setErrorCode()
+ *   setDetailedErrorMessage()
+ *   setDetailedErrorCode()
+ *
+ * 
+ * @package PureMachine\Bundle\SDKBundle\Exception
+ */
+interface ExceptionElementInterface
+{
+
+}

--- a/src/PureMachine/Bundle/SDKBundle/Exception/WebServiceException.php
+++ b/src/PureMachine/Bundle/SDKBundle/Exception/WebServiceException.php
@@ -34,7 +34,7 @@ class WebServiceException extends Exception
 
             if ($answer instanceof ErrorResponse) {
 
-                $message = $answer->getAnswer()->getCode() .": ". $answer->getAnswer()->getMessage() ." \n";
+                $message = $answer->getAnswer()->getErrorCode() .": ". $answer->getAnswer()->getErrorMessage() ." \n";
 
                 if ($answer->getAnswer()->isStoreProperty('detailledMessage')) {
                     $message .= $answer->getAnswer()->getDetailledMessage();
@@ -95,7 +95,7 @@ class WebServiceException extends Exception
                 if (class_exists($class)) {
                     $ex = null;
                     try {
-                        $ex = new $class($message, $answer->getAnswer()->getCode(), null);
+                        $ex = new $class($message, $answer->getAnswer()->getErrorCode(), null);
                         if ($ex instanceof Exception) {
                             $ex->setStore($answer->getAnswer());
                         }
@@ -109,8 +109,8 @@ class WebServiceException extends Exception
             }
 
             $e = new WebServiceException($message);
-            $e->getStore()->setMessage($answer->getAnswer()->getMessage());
-            $e->getStore()->setCode($answer->getAnswer()->getCode());
+            $e->getStore()->setErrorMessage($answer->getAnswer()->getErrorMessage());
+            $e->getStore()->setErrorCode($answer->getAnswer()->getErrorCode());
             throw $e;
         }
     }

--- a/src/PureMachine/Bundle/SDKBundle/Service/HttpHelper.php
+++ b/src/PureMachine/Bundle/SDKBundle/Service/HttpHelper.php
@@ -242,9 +242,9 @@ class HttpHelper
 
 
             $e = $this->createException($message, $exception_code);
-            $e->addMessage('output', $output);
-            $e->addMessage('called URL', $url);
-            $e->addMessage('data sent:', $data);
+            $e->addErrorMessage('output', $output);
+            $e->addErrorMessage('called URL', $url);
+            $e->addErrorMessage('data sent:', $data);
             $this->triggerHttpRequestEvent($data, $output, $url, $method, $statusCode, $duration);
             throw $e;
         }
@@ -253,9 +253,9 @@ class HttpHelper
             $e = $this->createException("HTTP exception: error " . $statusCode ." for ". $url
                                   ." . Page or service not found.",
                                   HTTPException::HTTP_404);
-            $e->addMessage('output', $output);
-            $e->addMessage('called URL', $url);
-            $e->addMessage('data sent:', $data);
+            $e->addErrorMessage('output', $output);
+            $e->addErrorMessage('called URL', $url);
+            $e->addErrorMessage('data sent:', $data);
             $this->triggerHttpRequestEvent($data, $output, $url, $method, $statusCode, $duration);
             throw $e;
         }
@@ -264,9 +264,9 @@ class HttpHelper
             $e = $this->createException("HTTP exception: error " . $statusCode ." for ". $url
                                   ." . Invalid credentials.",
                                    HTTPException::HTTP_401);
-            $e->addMessage('output', $output);
-            $e->addMessage('called URL', $url);
-            $e->addMessage('data sent:', $data);
+            $e->addErrorMessage('output', $output);
+            $e->addErrorMessage('called URL', $url);
+            $e->addErrorMessage('data sent:', $data);
             $this->triggerHttpRequestEvent($data, $output, $url, $method, $statusCode, $duration);
             throw $e;
         }
@@ -274,9 +274,9 @@ class HttpHelper
         if ($this->proxy && $statusCode == 100) {
             $errorMessage = "HTTP Timeout (100)for " . $url;
             $e = $this->createException($errorMessage, HTTPException::HTTP_100);
-            $e->addMessage('output', $output);
-            $e->addMessage('called URL', $url);
-            $e->addMessage('data sent:', $data);
+            $e->addErrorMessage('output', $output);
+            $e->addErrorMessage('called URL', $url);
+            $e->addErrorMessage('data sent:', $data);
             $this->triggerHttpRequestEvent($data, $output, $url, $method, $statusCode, $duration);
             throw $e;
         }
@@ -284,9 +284,9 @@ class HttpHelper
         if ($statusCode != 200) {
             $errorMessage = "HTTP exception: error " . $statusCode . " for $url";
             $e = $this->createException($errorMessage, HTTPException::HTTP_500);
-            $e->addMessage('output', $output);
-            $e->addMessage('called URL', $url);
-            $e->addMessage('data sent:', $data);
+            $e->addErrorMessage('output', $output);
+            $e->addErrorMessage('called URL', $url);
+            $e->addErrorMessage('data sent:', $data);
             $this->triggerHttpRequestEvent($data, $output, $url, $method, $statusCode, $duration);
             throw $e;
         }

--- a/src/PureMachine/Bundle/SDKBundle/Service/WebServiceClient.php
+++ b/src/PureMachine/Bundle/SDKBundle/Service/WebServiceClient.php
@@ -18,6 +18,7 @@ use PureMachine\Bundle\SDKBundle\Store\WebService\ErrorResponse;
 use PureMachine\Bundle\SDKBundle\Store\WebService\DebugErrorResponse;
 use PureMachine\Bundle\SDKBundle\Store\Base\StoreHelper;
 use Symfony\Component\Validator\Validation;
+use PureMachine\Bundle\SDKBundle\Exception\ExceptionElementInterface;
 
 /**
  * Needed because there is an annotation Inheritance bug in PHP 5.3.3 (centOS version)
@@ -424,7 +425,7 @@ class WebServiceClient
         //Translate the exception if possible
         if($this->isSymfony() && $this->symfonyContainer) {
             $translatedMessage = $this->translateException($data);
-            if(!is_null($translatedMessage)) $data->setMessage($translatedMessage);
+            if(!is_null($translatedMessage)) $data->setErrorMessage($translatedMessage);
         }
 
         if ($serialize) $data = $data->serialize();
@@ -458,8 +459,15 @@ class WebServiceClient
         if(!$this->isSymfony() || !$this->symfonyContainer) return null;
         $translator = $this->getSymfonyTranslator();
 
-        $translatedMessage = $translator->trans($store->getCode(), array(), 'messages', $translator->getLocale());
-        if($translatedMessage!=$store->getCode()) return $translatedMessage;
+        $errorCode = null;
+        if ($store instanceof ExceptionElementInterface) {
+            $errorCode = $store->getErrorCode();
+        } else {
+            $errorCode = $store->getCode();
+        }
+
+        $translatedMessage = $translator->trans($errorCode, array(), 'messages', $translator->getLocale());
+        if($translatedMessage!=$errorCode) return $translatedMessage;
 
         return null;
     }

--- a/src/PureMachine/Bundle/SDKBundle/Store/ExceptionStore.php
+++ b/src/PureMachine/Bundle/SDKBundle/Store/ExceptionStore.php
@@ -3,32 +3,53 @@ namespace PureMachine\Bundle\SDKBundle\Store;
 
 use Symfony\Component\Validator\Constraints as Assert;
 use PureMachine\Bundle\SDKBundle\Store\Annotation as Store;
+use PureMachine\Bundle\SDKBundle\Exception\ExceptionElementInterface;
 
 /**
  * Class ExceptionStore
  * @package PureMachine\Bundle\SDKBundle\Store
  *
- * @method getMessage()
- * @method getCode()
+ * @method getErrorMessage()
+ * @method getErrorCode()
+ * @method getDetailedErrorMessage()
+ * @method getDetailedErrorCode()
  * @method getExceptionClass()
  * @method getTicket()
  * @method getDetailledMessage()
+ * @method setErrorMessage()
+ * @method setErrorCode()
+ * @method setDetailedErrorMessage()
+ * @method setDetailedErrorCode()
  */
-class ExceptionStore extends Base\BaseStore
+class ExceptionStore extends Base\BaseStore implements ExceptionElementInterface
 {
     /**
      * @Store\Property(description="Exception generic message")
      * @Assert\Type("string")
      * @Assert\NotBlank
      */
-    protected $message;
+    protected $errorMessage;
 
     /**
      * @Store\Property(description="Exception error code.")
      * @Assert\Type("string")
      * @Assert\NotBlank
      */
-    protected $code;
+    protected $errorCode;
+
+    /**
+     * @Store\Property(description="Raw exception generic message")
+     * @Assert\Type("string")
+     * @Assert\NotBlank
+     */
+    protected $detailedErrorMessage;
+
+    /**
+     * @Store\Property(description="Raw exception error code.")
+     * @Assert\Type("string")
+     * @Assert\NotBlank
+     */
+    protected $detailedErrorCode;
 
     /**
      * @Store\Property(description="Full exception class name.")
@@ -97,7 +118,7 @@ class ExceptionStore extends Base\BaseStore
 
     public function getCompleteMessage()
     {
-        return $this->getMessage(). ": " . $this->getDetailledMessage()
+        return $this->getErrorMessage(). ": " . $this->getDetailledMessage()
                ." in " . $this->getFile() .":" . $this->getLine();
     }
 
@@ -106,6 +127,24 @@ class ExceptionStore extends Base\BaseStore
         $this->metadata[$key] = $value;
 
         return $this;
+    }
+
+    /***
+     * FIXME: For retrocompatibility, to remove
+     * @return mixed
+     */
+    public function getMessage()
+    {
+        return $this->errorMessage;
+    }
+
+    /***
+     * FIXME: For retrocompatibility, to remove
+     * @return mixed
+     */
+    public function getCode()
+    {
+        return $this->errorCode;
     }
 
 }

--- a/src/PureMachine/Bundle/SDKBundle/Tests/ExceptionTest.php
+++ b/src/PureMachine/Bundle/SDKBundle/Tests/ExceptionTest.php
@@ -4,10 +4,12 @@ namespace PureMachine\Bundle\SDKBundle\Tests;
 
 use PureMachine\Bundle\SDKBundle\Exception\Exception;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use PureMachine\Bundle\StoreBundle\Store\Base\BaseStoreInterface;
+use PureMachine\Bundle\SDKBundle\Exception\ExceptionElementInterface;
 
 /**
  * @code
-     * ./bin/phpunit -v -c app vendor/puremachine/sdk/src/PureMachine/Bundle/SDKBundle/Tests/ExceptionTest.php
+ * ./bin/phpunit -v -c app vendor/puremachine/sdk/src/PureMachine/Bundle/SDKBundle/Tests/ExceptionTest.php
  * @endcode
  */
 class ExceptionTest extends WebTestCase
@@ -15,7 +17,7 @@ class ExceptionTest extends WebTestCase
 
     /**
      * @code
-     * phpunit -v --filter testMetadataGetterSetterAdder -c app vendor/puremachine/sdk/src/PureMachine/Bundle/SDKBundle/Tests/ExceptionTest.php
+     * ./bin/phpunit -v --filter testMetadataGetterSetterAdder -c app vendor/puremachine/sdk/src/PureMachine/Bundle/SDKBundle/Tests/ExceptionTest.php
      * @endcode
      */
     public function testMetadataGetterSetterAdder()
@@ -38,6 +40,23 @@ class ExceptionTest extends WebTestCase
         $tmpValues = $Exception->getMetadata();
         $this->assertEquals('value', $tmpValues['key']);
         $this->assertEquals('value3', $tmpValues['key2']);
+    }
+
+    /**
+     * @code
+     * ./bin/phpunit -v --filter testCreateExceptionStoreFromException -c app vendor/puremachine/sdk/src/PureMachine/Bundle/SDKBundle/Tests/ExceptionTest.php
+     * @endcode
+     */
+    public function testCreateExceptionStoreFromException()
+    {
+        $exception = new Exception();
+
+        $store = $exception->buildExceptionStore(new \Exception("sample simple exception", -1101));
+
+        $this->assertEquals('sample simple exception', $store->getErrorMessage());
+        $this->assertEquals(-1101, $store->getErrorCode());
+        $this->assertTrue($store instanceof BaseStoreInterface);
+        $this->assertTrue($store instanceof ExceptionElementInterface);
     }
 
 }


### PR DESCRIPTION
Renames the code and message from internal Error store to errorCode
and errorMessage.

Also adds detailedErrorCode and detailedErrorMessage to the error store

See: #33217
